### PR TITLE
Fix A/B ordering logic bug

### DIFF
--- a/utils/database.py
+++ b/utils/database.py
@@ -339,9 +339,11 @@ class RLHFDatabase:
                 # chosen_index should be set based on which completion was actually chosen
                 chosen_index = 0 if annotation_data["preference"] == "Completion A" else 1
             else:
-                # Legacy fallback - this creates inconsistent A/B ordering
-                completion_a = annotation_data["selected_completion"] if annotation_data["preference"] == "Completion A" else annotation_data["rejected_completion"]
-                completion_b = annotation_data["rejected_completion"] if annotation_data["preference"] == "Completion A" else annotation_data["selected_completion"]
+                # FIXED: Use consistent A/B ordering (same as _add_model_prediction)
+                # Always assign: A = selected_completion, B = rejected_completion
+                completion_a = annotation_data.get("selected_completion", "")
+                completion_b = annotation_data.get("rejected_completion", "")
+                # chosen_index is 0 if selected was chosen (A), 1 if rejected was chosen (B)
                 chosen_index = 0 if annotation_data["preference"] == "Completion A" else 1
             
             return {


### PR DESCRIPTION
Standardize A/B completion ordering in `_create_standardized_vote_record` to match `_add_model_prediction`.

This resolves an inconsistency where `_add_model_prediction` always assigned `selected_completion` to `completion_a` and `rejected_completion` to `completion_b`, while `_create_standardized_vote_record` used the `preference` field for A/B assignment in its fallback. This mismatch led to incorrect model correctness evaluations.